### PR TITLE
chore: add `langchain-unstructured` package to the requirements file

### DIFF
--- a/requirements-text-only.txt
+++ b/requirements-text-only.txt
@@ -1,6 +1,7 @@
 fastapi
 langchain
 langchain-community
+langchain-unstructured
 python-multipart
 unstructured
 psutil


### PR DESCRIPTION
For the build of Dockerfile-Text-Only.